### PR TITLE
use local realpath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ bc.old
 .results.txt
 .ops.txt
 gen/strgen
+realpath/realpath
 lib.c
 lib2.c
 lib3.c

--- a/Makefile.in
+++ b/Makefile.in
@@ -48,6 +48,11 @@ GEN = strgen
 GEN_EXEC = $(GEN_DIR)/$(GEN)
 GEN_C = $(GEN_DIR)/$(GEN).c
 
+REALPATH_DIR = realpath
+REALPATH = realpath
+REALPATH_EXEC = $(REALPATH_DIR)/$(REALPATH)
+REALPATH_C    = $(REALPATH_DIR)/$(REALPATH).c
+
 GEN_EMU = %%GEN_EMU%%
 
 BC_LIB = $(GEN_DIR)/lib.bc
@@ -138,6 +143,9 @@ all: make_bin $(DC_HELP_O) $(BC_HELP_O) $(BC_LIB_O) $(BC_LIB2_O) $(BC_LIB3_O) $(
 
 $(GEN_EXEC):
 	$(HOSTCC) $(HOSTCFLAGS) -o $(GEN_EXEC) $(GEN_C)
+
+$(REALPATH_EXEC):
+	$(HOSTCC) $(HOSTCFLAGS) -o $(REALPATH_EXEC) $(REALPATH_C)
 
 $(BC_LIB_C): $(GEN_EXEC) $(BC_LIB)
 	$(GEN_EMU) $(GEN_EXEC) $(BC_LIB) $(BC_LIB_C) bc_lib bc.h bc_lib_name $(BC_ENABLED_NAME) 1
@@ -268,7 +276,7 @@ install_bc_manpage:
 install_dc_manpage:
 	$(SAFE_INSTALL) $(MANPAGE_INSTALL_ARGS) $(DC_MANPAGE) $(DESTDIR)$(MAN1DIR)/$(DC_MANPAGE_NAME)
 
-install:%%INSTALL_PREREQS%%
+install:%%INSTALL_PREREQS%% $(REALPATH_EXEC)
 	$(INSTALL) $(DESTDIR)$(BINDIR) $(BIN) "$(EXEC_SUFFIX)"
 
 uninstall_bc_manpage:

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ usage() {
 	exit 1
 }
 
-script=$(realpath "$0")
+script=$(./realpath/realpath "$0")
 scriptdir=$(dirname "$script")
 
 INSTALL="$scriptdir/safe-install.sh"

--- a/realpath/realpath.c
+++ b/realpath/realpath.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <errno.h>
+#include <string.h>
+
+#define USAGE "realpath FILE\n"
+
+int main(int argc, char *argv[]) {
+    char resolved[PATH_MAX+1];
+    char *p;
+
+    if(argc < 2) {
+        fprintf(stderr,USAGE);
+        fflush(stderr);
+        return 1;
+    }
+
+    p = realpath(argv[1],resolved);
+
+    if(p == NULL) {
+        fprintf(stderr,"Error: %s\n",strerror(errno));
+        fflush(stderr);
+        return 1;
+    }
+
+    fprintf(stdout,"%s\n",resolved);
+
+    return 0;
+}


### PR DESCRIPTION
Hi there - I tried installing bc on macOS, which doesn't have a `realpath` program, same applies to some older linux distros like CentOS 6. As far as I can tell, `realpath` isn't specified in POSIX.

This compiles a small utility to run at install-time for finding the real path of a file.