### PR TITLE
avoid ./ in symlink paths, use readlink instead of ls to resolve link

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,8 +39,7 @@ for exe in $bindir/*; do
 	base=$(basename "$exe")
 
 	if [ -L "$exe" ]; then
-		L=$(ls -dl "$exe")
-		link=$(printf ${L#*-> })
+		link=$(readlink "$exe")
 		"$INSTALL" -Dlm 755 "$link$exec_suffix" "$installdir/$base$exec_suffix"
 	else
 		"$INSTALL" -Dm 755 "$exe" "$installdir/$base$exec_suffix"

--- a/link.sh
+++ b/link.sh
@@ -27,9 +27,8 @@ shift
 link="$1"
 shift
 
-cd "$bindir"
 
-for exe in ./*; do
+for exe in "$bindir"/*; do
 
 	if [ ! -L "$exe" ]; then
 
@@ -42,7 +41,7 @@ for exe in ./*; do
 			name="$link"
 		fi
 
-		ln -fs "$exe" "./$name"
+		ln -fs "$base" "$bindir/$name"
 	fi
 
 done


### PR DESCRIPTION
Just some minor tweaks - I noticed the symlinks were being generated with "./" in them, which isn't necessary.

I also switch `install.sh` to use `readlink` to resolve symlinks, instead of parsing the output of ls. Both methods are support by POSIX, I just think `readlink` makes it more apparent what's going on.