### PR TITLE
Fix EOF behavior in interactive mode with history

### DIFF
--- a/src/history/history.c
+++ b/src/history/history.c
@@ -1238,7 +1238,7 @@ BcStatus bc_history_line(BcHistory *h, BcVec *vec, const char *prompt) {
 	if (BC_TTYIN && !vm->history.badTerm) {
 
 		s = bc_history_raw(h, prompt);
-		if (BC_ERR(s)) return s;
+		if (BC_ERR(s && s != BC_STATUS_EOF)) return s;
 
 		bc_vec_string(vec, BC_HISTORY_BUF_LEN(h), h->buf.v);
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -412,7 +412,7 @@ static BcStatus bc_vm_stdin(void) {
 	// with a backslash to the parser. The reason for that is because the parser
 	// treats a backslash+newline combo as whitespace, per the bc spec. In that
 	// case, and for strings and comments, the parser will expect more stuff.
-	for (; !done && !BC_STATUS_IS_ERROR(s) && buf.len > 1 && BC_NO_SIG &&
+	for (; !BC_STATUS_IS_ERROR(s) && buf.len > 1 && BC_NO_SIG &&
 	       s != BC_STATUS_SIGNAL; s = bc_read_line(&buf, ">>> "))
 	{
 		char c2, *str = buf.v;
@@ -460,6 +460,8 @@ static BcStatus bc_vm_stdin(void) {
 		if (BC_ERR(s)) goto err;
 
 		bc_vec_empty(&buffer);
+
+		if (done) break;
 	}
 
 	if (BC_ERR(s && s != BC_STATUS_EOF)) goto err;


### PR DESCRIPTION
Previously, EOF would re-process the previous line, read one more
line, then exit. This is because bc_history_line left the buffer
untouched in case of EOF, and the bc_vm_stdin loop reads the next
line before checking the `done` condition of the previous iteration.

This fix also prevents reading past the end of the buffer if the
first user input is EOF, since in that case vec->len is still 0,
so (size_t)-1 is passed to bc_read_binary.