### PR TITLE
Install real catalog files first, then links for alias names.

### DIFF
--- a/locale_install.sh
+++ b/locale_install.sh
@@ -64,11 +64,31 @@ for file in $locales_dir/*.msg; do
 	mkdir -p $(dirname "$loc")
 
 	if [ -L "$file" ]; then
-		link=$(readlink "$file")
-		d=$(dirname "$file")
-		file="$d/$link"
+		continue
 	fi
 
 	gencat "$loc" "$file" > /dev/null 2>&1
+
+done
+
+for file in $locales_dir/*.msg; do
+
+	base=$(basename "$file")
+	locale=$(removeext "$base")
+	loc=$(gen_nlspath "$nlspath" "$locale" "$main_exec")
+
+	if [ ! -z "${locales##*$locale*}" ]; then
+		continue
+	fi
+
+	mkdir -p $(dirname "$loc")
+
+	if [ -L "$file" ]; then
+		link=$(readlink "$file")
+		locale=$(basename "$link" .msg)
+		linksrc="$(gen_nlspath "$nlspath" "$locale" "$main_exec")"
+
+		ln "$linksrc" "$loc"
+	fi
 
 done


### PR DESCRIPTION
Suggestion of an alternate installation sequence for catalog files.

First the "real" files are installed, then (hard) links added to provide the aliases.
Since all catalog files should be on the same file system, the use of hard links should be OK ...