### PR TITLE
Test should use the file name created if the file is not found

### DIFF
--- a/locale_install.sh
+++ b/locale_install.sh
@@ -104,7 +104,7 @@ for file in $locales_dir/*.msg; do
 		locale=$(basename "$link" .msg)
 		linksrc=$(gen_nlspath "$nlspath" "$locale" "$main_exec")
 
-		if [ ! -f "$linksrc" ]; then
+		if [ ! -f "$destdir/$linksrc" ]; then
 			gencatfile "$destdir/$linksrc" "$link"
 		fi
 


### PR DESCRIPTION
If $destdir is set, the test did not check the existence of the file that was required for the symlink operation (and created by the conditional gencat). That lead to the file being re-created if not found at the location of the final destination (ignoring $destdir), even though it existed at $destdir/$linksrc.