### PR TITLE
Slightly speed up printing for the obase!=10 case

### DIFF
--- a/src/num.c
+++ b/src/num.c
@@ -1801,10 +1801,16 @@ static BcStatus bc_num_printNum(BcNum *restrict n, BcBigDig base,
 
 		acc = (BcBigDig) intp.num[i];
 
-		for (j = 0; BC_NO_SIG && j < exp && (i < intp.len - 1 || acc != 0); ++j)
-		{
-			dig = acc % base;
-			acc /= base;
+		for (j = 0; BC_NO_SIG && j < exp && (i < intp.len - 1 || acc != 0); ++j) {
+			if (j != exp - 1) {
+				dig = acc % base;
+				acc /= base;
+			}
+			else {
+				dig = acc;
+				acc = 0;
+			}
+			assert(dig < base);
 			bc_vec_push(&stack, &dig);
 		}
 


### PR DESCRIPTION
In the last iteration of the per BcDig print loop, "acc" is known to be less than "pow", therefore the last div and mod operations can be skipped, resulting in a speed-up of about 2% in my tests.