### PR TITLE
Improve worst case behavior of the division

### DIFF
--- a/src/num.c
+++ b/src/num.c
@@ -2460,6 +2460,5 @@ void bc_num_dump(const char *varname, const BcNum *n) {
 
 	fprintf(stderr, "(%zu | %zu.%zu / %zu) %p\n",
 	        n->scale, n->len, n->rdx, n->cap, (void*) n->num);
-	vm->nchars = 0;
 }
 #endif // BC_DEBUG_CODE

--- a/src/program.c
+++ b/src/program.c
@@ -481,7 +481,7 @@ static void bc_program_printChars(const char *str) {
 	const char *nl;
 	vm->nchars += bc_vm_printf("%s", str);
 	nl = strrchr(str, '\n');
-	if (nl) vm->nchars = strlen(nl - 1);
+	if (nl) vm->nchars = strlen(nl + 1);
 }
 
 static void bc_program_printString(const char *restrict str) {

--- a/src/program.c
+++ b/src/program.c
@@ -481,7 +481,7 @@ static void bc_program_printChars(const char *str) {
 	const char *nl;
 	vm->nchars += bc_vm_printf("%s", str);
 	nl = strrchr(str, '\n');
-	if (nl) vm->nchars = strlen(nl + 1);
+	if (nl) vm->nchars = strlen(nl - 1);
 }
 
 static void bc_program_printString(const char *restrict str) {


### PR DESCRIPTION
Reduce the number of iterations required for cases where the top-most BcDig of the divisor is a small value and there are lower non-zero BcDigs. This makes the performance of the division more even for all types of operands of a given length and speeds up "make test" by about 3% on my system. The worst case performance of the division is improved by about a factor of 20 (estimated, not measured) for operations like 1/1.000000001.