### PR TITLE
Small performance optimization (perhaps for the next following release?)

### DIFF
--- a/src/num.c
+++ b/src/num.c
@@ -981,7 +981,7 @@ static BcStatus bc_num_d_long(BcNum *restrict a, BcNum *restrict b,
 
 	if (len > 1 && bc_num_nonZeroDig(b->num, len - 1)) {
 
-		nonzero = (divisor >= BC_BASE_POW / BC_BASE);
+		nonzero = (divisor >= BC_BASE_POW / (BC_BASE * BC_BASE));
 
 		if (!nonzero) {
 


### PR DESCRIPTION
Benchmarks show a small but significant speed-up of "make test" if the
limit for the shifting of operands is made more strict. Many operands
will require a second iteration of the inner loop anyway, and shifting
of the operands uses cycles for no gain, then.

To my surprise, BC_BASE_DIGS=4 and =9 seem to have near identical
performance after this change. Some operations (multiplication and
power) ought to be faster with larger BcDigs, but at least for the
performance of "make test" on my system this does not seem to affect
the run-time by a significant amount.