### PR TITLE
Emacs delete-next-character

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -1535,12 +1535,19 @@ static BcStatus bc_history_edit(BcHistory *h, const char *prompt) {
 			}
 
 #ifndef _WIN32
-			// Act as end-of-file.
+			// Act as end-of-file or delete-forward-char
 			case BC_ACTION_CTRL_D:
 			{
-				bc_history_printCtrl(h, c);
-				BC_SIG_UNLOCK;
-				return BC_STATUS_EOF;
+				// Act as EOF if there's no chacters, otherwise
+				// emulate emace delete next character to match
+				// historical gnu bc behavior.
+				if (BC_HIST_BUF_LEN(h) == 0) {
+					bc_history_printCtrl(h, c);
+					BC_SIG_UNLOCK;
+					return BC_STATUS_EOF;
+				}
+				bc_history_edit_delete(h);
+				break;
 			}
 #endif // _WIN32
 


### PR DESCRIPTION
The historic gnu bc behavior was to have ^D be delete next character if
there were any characters in the input, or end of file if there
weren't. This matches what emacs users expect for editing the command
line. Implement this by assuming end of file if the input is empty, and
delete forward character if it isn't.

Signed-off-by: Warner Losh <imp@bsdimp.com>