### PR TITLE
Improve Reproducibility (Reproducible Builds)

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -457,7 +457,7 @@ find_src_files() {
 
 	fi
 
-	_find_src_files_files=$(find "$scriptdir/src/" -depth -name "*.c" -print)
+	_find_src_files_files=$(find "$scriptdir/src/" -depth -name "*.c" -print | LC_ALL=C sort -z)
 
 	_find_src_files_result=""
 

--- a/configure.sh
+++ b/configure.sh
@@ -457,7 +457,7 @@ find_src_files() {
 
 	fi
 
-	_find_src_files_files=$(find "$scriptdir/src/" -depth -name "*.c" -print | LC_ALL=C sort -z)
+	_find_src_files_files=$(find "$scriptdir/src/" -depth -name "*.c" -print | LC_ALL=C sort)
 
 	_find_src_files_result=""
 


### PR DESCRIPTION
On POSIX systems, `find` may have indeterministic output (I believe based on the inode on the filesystem).
`sort` is needed to ensure the output is deterministic.

In my builds, this resulted in the build order in the generated `Makefile` changing around.
Thus building on a fresh partition made with `mkfs.ext4` would result in the binary being different each time.
The compiled binary code in the`bc` binary shuffled around depending on which files were built first.
Possibly the build order in the Makefile was affecting the order in which files were linked?

I added `LC_ALL=C` recommended by reproducible-builds.org. 
See below for reference:
- [https://reproducible-builds.org/docs/archives/](https://reproducible-builds.org/docs/archives/)
- [https://reproducible-builds.org/docs/stable-inputs/](https://reproducible-builds.org/docs/stable-inputs/)