### PR TITLE
Fix incorrect processing of env:BC_LINE_LENGTH=0

### DIFF
--- a/src/vm.c
+++ b/src/vm.c
@@ -622,8 +622,11 @@ bc_vm_envLen(const char* var)
 	if (num)
 	{
 		// Parse it and clamp it if needed.
-		len = (size_t) atoi(lenv) - 1;
-		if (len == 1 || len >= UINT16_MAX) len = BC_NUM_PRINT_WIDTH;
+		len = (size_t) strtol(lenv, NULL, 10);
+		if (len) {
+			if (len < 3 || len > UINT16_MAX) len = BC_NUM_PRINT_WIDTH;
+			else len--;
+		}
 	}
 	// Set the default.
 	else len = BC_NUM_PRINT_WIDTH;


### PR DESCRIPTION
Casting int -1 to size_t produces SIZE_T_MAX so
BC_NUM_PRINT_WIDTH is used instead of 0