### PR TITLE
Make configure.sh posix compliant

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -1690,7 +1690,7 @@ else
 fi
 
 # We can't use the linker's strip flag on macOS.
-if [ "$debug" -eq 0 ] && [ "$apple" == "" ] && [ "$strip_bin" -ne 0 ]; then
+if [ "$debug" -eq 0 ] && [ "$apple" = "" ] && [ "$strip_bin" -ne 0 ]; then
 	LDFLAGS="-s $LDFLAGS"
 fi
 


### PR DESCRIPTION
This avoids the `./configure.sh: 1693: [: unexpected operator` error when using dash.