### PR TITLE
Don't unconditionally enable warnings after ignoring them

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -291,11 +291,12 @@ bc_file_vprintf(BcFile* restrict f, const char* fmt, va_list args)
 
 		// This mess is to silence a warning.
 #if BC_CLANG
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wformat-nonliteral"
 #endif // BC_CLANG
 		r = vfprintf(f->f, fmt, args);
 #if BC_CLANG
-#pragma clang diagnostic warning "-Wformat-nonliteral"
+#pragma clang diagnostic pop
 #endif // BC_CLANG
 
 		// Just print and propagate the error.

--- a/src/program.c
+++ b/src/program.c
@@ -3039,10 +3039,12 @@ bc_program_exec(BcProgram* p)
 #if BC_HAS_COMPUTED_GOTO
 
 #if BC_GCC
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif // BC_GCC
 
 #if BC_CLANG
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-label-as-value"
 #endif // BC_CLANG
 
@@ -3050,11 +3052,11 @@ bc_program_exec(BcProgram* p)
 	BC_PROG_LBLS_ASSERT;
 
 #if BC_CLANG
-#pragma clang diagnostic warning "-Wgnu-label-as-value"
+#pragma clang diagnostic pop
 #endif // BC_CLANG
 
 #if BC_GCC
-#pragma GCC diagnostic warning "-Wpedantic"
+#pragma GCC diagnostic pop
 #endif // BC_GCC
 
 	// BC_INST_INVALID is a marker for the end so that we don't have to have an
@@ -3085,10 +3087,12 @@ bc_program_exec(BcProgram* p)
 #if BC_HAS_COMPUTED_GOTO
 
 #if BC_GCC
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #endif // BC_GCC
 
 #if BC_CLANG
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgnu-label-as-value"
 #endif // BC_CLANG
 
@@ -3711,11 +3715,11 @@ bc_program_exec(BcProgram* p)
 #if BC_HAS_COMPUTED_GOTO
 
 #if BC_CLANG
-#pragma clang diagnostic warning "-Wgnu-label-as-value"
+#pragma clang diagnostic pop
 #endif // BC_CLANG
 
 #if BC_GCC
-#pragma GCC diagnostic warning "-Wpedantic"
+#pragma GCC diagnostic pop
 #endif // BC_GCC
 
 #else // BC_HAS_COMPUTED_GOTO

--- a/src/vm.c
+++ b/src/vm.c
@@ -222,11 +222,12 @@ bc_vm_sigaction(void)
 	// This mess is to silence a warning on Clang with regards to glibc's
 	// sigaction handler, which activates the warning here.
 #if BC_CLANG
+#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdisabled-macro-expansion"
 #endif // BC_CLANG
 	sa.sa_handler = bc_vm_sig;
 #if BC_CLANG
-#pragma clang diagnostic warning "-Wdisabled-macro-expansion"
+#pragma clang diagnostic pop
 #endif // BC_CLANG
 
 	sigaction(SIGTERM, &sa, NULL);


### PR DESCRIPTION
It's possible that the warning being ignored wasn't enabled in the first place, so always enabling it again is wrong.

In practice, this resulted in unexpected -Wdisabled-macro-expansion warnings when compiling against musl libc.