### PR TITLE
Let libedit handle terminal size changes.

### DIFF
--- a/include/history.h
+++ b/include/history.h
@@ -120,30 +120,6 @@ typedef struct BcHistory
 extern const char bc_history_editrc[];
 extern const size_t bc_history_editrc_len;
 
-#ifdef __APPLE__
-
-/**
- * Returns true if the line is a valid line, false otherwise.
- * @param line  The line.
- * @param len   The length of the line.
- * @return      True if the line is valid, false otherwise.
- */
-#define BC_HISTORY_INVALID_LINE(line, len) \
-	((line) == NULL && ((len) == -1 || errno == EINTR))
-
-#else // __APPLE__
-
-/**
- * Returns true if the line is a valid line, false otherwise.
- * @param line  The line.
- * @param len   The length of the line.
- * @return      True if the line is valid, false otherwise.
- */
-#define BC_HISTORY_INVALID_LINE(line, len) \
-	((line) == NULL && (len) == -1 && errno == EINTR)
-
-#endif // __APPLE__
-
 #else // BC_ENABLE_EDITLINE
 
 #if BC_ENABLE_READLINE

--- a/include/status.h
+++ b/include/status.h
@@ -683,12 +683,7 @@ typedef enum BcMode
 #define BC_NO_SIG_EXC(vm) \
 	BC_LIKELY((vm)->status == (sig_atomic_t) BC_STATUS_SUCCESS && !(vm)->sig)
 
-#ifndef _WIN32
-#define BC_SIG_INTERRUPT(vm) \
-	BC_UNLIKELY((vm)->sig != 0 && (vm)->sig != SIGWINCH)
-#else // _WIN32
 #define BC_SIG_INTERRUPT(vm) BC_UNLIKELY((vm)->sig != 0)
-#endif // _WIN32
 
 #if BC_DEBUG
 

--- a/src/history.c
+++ b/src/history.c
@@ -199,6 +199,7 @@ bc_history_init(BcHistory* h)
 
 	h->el = el_init(vm->name, stdin, stdout, stderr);
 	if (BC_ERR(h->el == NULL)) bc_vm_fatalError(BC_ERR_FATAL_ALLOC_ERR);
+	el_set(h->el, EL_SIGNAL, 1);
 
 	// I want history and a prompt.
 	history(h->hist, &bc_history_event, H_SETSIZE, 100);
@@ -264,18 +265,7 @@ bc_history_line(BcHistory* h, BcVec* vec, const char* prompt)
 	errno = EINTR;
 
 	// Get the line.
-	//
-	// XXX: Why have a macro here? Because macOS needs to be special. Honestly,
-	// it's starting to feel special like Windows at this point. Anyway, the
-	// second SIGWINCH signal of multiple will  return a valid line length on
-	// macOS, so we need to allow for that on macOS. However, FreeBSD's editline
-	// is different and will mess up the terminal if we do it that way.
-	//
-	// There is one limitation with this, however: Ctrl+D won't work on macOS.
-	// But it's because of macOS that this problem exists, and I can't really do
-	// anything about it. So macOS should fix their broken editline; once they
-	// do, I'll fix Ctrl+D on macOS.
-	while (BC_HISTORY_INVALID_LINE(line, len))
+	while (line == NULL && len == -1 && errno == EINTR)
 	{
 		line = el_gets(h->el, &len);
 		bc_history_use_prompt = false;

--- a/src/read.c
+++ b/src/read.c
@@ -185,20 +185,14 @@ bc_read_chars(BcVec* vec, const char* prompt)
 				vm->sig = 0;
 				vm->status = (sig_atomic_t) BC_STATUS_SUCCESS;
 
-#ifndef _WIN32
-				// We don't want to print anything on a SIGWINCH.
-				if (sig != SIGWINCH)
-#endif // _WIN32
+				// Print the ready message and prompt again.
+				bc_file_puts(&vm->fout, bc_flush_none,
+					     bc_program_ready_msg);
+				if (BC_PROMPT)
 				{
-					// Print the ready message and prompt again.
-					bc_file_puts(&vm->fout, bc_flush_none,
-					             bc_program_ready_msg);
-					if (BC_PROMPT)
-					{
-						bc_file_puts(&vm->fout, bc_flush_none, prompt);
-					}
-					bc_file_flush(&vm->fout, bc_flush_none);
+					bc_file_puts(&vm->fout, bc_flush_none, prompt);
 				}
+				bc_file_flush(&vm->fout, bc_flush_none);
 
 				BC_SIG_UNLOCK;
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -124,27 +124,6 @@ bc_vm_jmp(void)
 static void
 bc_vm_sig(int sig)
 {
-#if BC_ENABLE_EDITLINE
-	// Editline needs this to resize the terminal. This also needs to come first
-	// because a resize always needs to happen.
-	if (sig == SIGWINCH)
-	{
-		if (BC_TTY)
-		{
-			el_resize(vm->history.el);
-
-			// If the signal was a SIGWINCH, clear it because we don't need to
-			// print a stack trace in that case.
-			if (vm->sig == SIGWINCH)
-			{
-				vm->sig = 0;
-			}
-		}
-
-		return;
-	}
-#endif // BC_ENABLE_EDITLINE
-
 	// There is already a signal in flight if this is true.
 	if (vm->status == (sig_atomic_t) BC_STATUS_QUIT || vm->sig != 0)
 	{
@@ -233,11 +212,6 @@ bc_vm_sigaction(void)
 	sigaction(SIGTERM, &sa, NULL);
 	sigaction(SIGQUIT, &sa, NULL);
 	sigaction(SIGINT, &sa, NULL);
-
-#if BC_ENABLE_EDITLINE
-	// Editline needs this to resize the terminal.
-	if (BC_TTY) sigaction(SIGWINCH, &sa, NULL);
-#endif // BC_ENABLE_EDITLINE
 
 #if BC_ENABLE_HISTORY
 	if (BC_TTY) sigaction(SIGHUP, &sa, NULL);


### PR DESCRIPTION
Previously, we would catch `SIGWINCH` and call `el_resize()` from the signal handler.  This is unsafe and led to strange behavior such as terminating on second resize.  The simplest solution is to let libedit handle `SIGWINCH` itself.

This reverts 56bb18255a24 and 89d6c3451a60 and removes all traces of `SIGWINCH` from bc itself, and instead sets the `EL_SIGNAL` flag on the editline context, which causes libedit to detect and handle terminal size changes internally.