### PR TITLE
Added stack directive and global_pop function

### DIFF
--- a/include/bc.h
+++ b/include/bc.h
@@ -96,13 +96,13 @@ typedef struct BcLexKeyword
 
 /// A macro for the number of keywords bc has. This has to be updated if any are
 /// added. This is for the redefined_kws field of the BcVm struct.
-#define BC_LEX_NKWS (37)
+#define BC_LEX_NKWS (38)
 
 #else // BC_ENABLE_EXTRA_MATH
 
 /// A macro for the number of keywords bc has. This has to be updated if any are
 /// added. This is for the redefined_kws field of the BcVm struct.
-#define BC_LEX_NKWS (33)
+#define BC_LEX_NKWS (34)
 
 #endif // BC_ENABLE_EXTRA_MATH
 

--- a/include/lang.h
+++ b/include/lang.h
@@ -328,6 +328,9 @@ typedef enum BcInst
 
 #endif // DC_ENABLED
 
+	/// Pop the global stacks.
+	BC_INST_GLOBAL_POP,
+
 	/// Invalid instruction.
 	BC_INST_INVALID,
 
@@ -409,6 +412,9 @@ typedef struct BcFunc
 #if BC_ENABLED
 	/// True if the function is a void function.
 	bool voidfn;
+
+	/// True if the function is a stack function (uses global stacks).
+	bool stackfn;
 #endif // BC_ENABLED
 
 } BcFunc;

--- a/include/lex.h
+++ b/include/lex.h
@@ -407,6 +407,9 @@ typedef enum BcLexType
 	/// bc else keyword.
 	BC_LEX_KW_ELSE,
 
+	/// bc GLOBAL_POP keyword.
+	BC_LEX_KW_GLOBAL_POP,
+
 #if DC_ENABLED
 
 	/// dc extended registers keyword.

--- a/include/parse.h
+++ b/include/parse.h
@@ -201,6 +201,9 @@ typedef struct BcParse
 	/// True if the bc parser just entered a function and an auto statement
 	/// would be valid.
 	bool auto_part;
+
+	/// True if the bc parser is in a stack function.
+	bool stackfn;
 #endif // BC_ENABLED
 
 } BcParse;

--- a/include/program.h
+++ b/include/program.h
@@ -631,6 +631,7 @@ extern const char bc_program_esc_seqs[];
 		&&lbl_BC_INST_QUIT,                             \
 		&&lbl_BC_INST_NQUIT,                            \
 		&&lbl_BC_INST_EXEC_STACK_LEN,                   \
+		&&lbl_BC_INST_GLOBAL_POP,                        \
 		&&lbl_BC_INST_INVALID,                          \
 	}
 
@@ -822,6 +823,7 @@ extern const char bc_program_esc_seqs[];
 		&&lbl_BC_INST_MODEXP,                           \
 		&&lbl_BC_INST_DIVMOD,                           \
 		&&lbl_BC_INST_PRINT_STREAM,                     \
+		&&lbl_BC_INST_GLOBAL_POP,                        \
 		&&lbl_BC_INST_INVALID,                          \
 	}
 
@@ -949,7 +951,7 @@ extern const char bc_program_esc_seqs[];
 		&&lbl_BC_INST_LOAD,          &&lbl_BC_INST_PUSH_VAR,           \
 		&&lbl_BC_INST_PUSH_TO_VAR,   &&lbl_BC_INST_QUIT,               \
 		&&lbl_BC_INST_NQUIT,         &&lbl_BC_INST_EXEC_STACK_LEN,     \
-		&&lbl_BC_INST_INVALID,                                         \
+		&&lbl_BC_INST_GLOBAL_POP,     &&lbl_BC_INST_INVALID,                                         \
 	}
 
 #else // BC_ENABLE_EXTRA_MATH

--- a/include/status.h
+++ b/include/status.h
@@ -595,6 +595,9 @@ typedef enum BcErr
 	/// Non-POSIX void error.
 	BC_ERR_POSIX_VOID,
 
+	/// Non-POSIX stack error.
+	BC_ERR_POSIX_STACK,
+
 	/// Non-POSIX brace position used error.
 	BC_ERR_POSIX_BRACE,
 

--- a/src/data.c
+++ b/src/data.c
@@ -895,6 +895,7 @@ const BcLexKeyword bc_lex_kws[] = {
 	BC_LEX_KW_ENTRY("leading_zero", 12, false),
 	BC_LEX_KW_ENTRY("stream", 6, false),
 	BC_LEX_KW_ENTRY("else", 4, false),
+	BC_LEX_KW_ENTRY("global_pop", 11, false),
 };
 
 /// The length of the list of bc keywords.

--- a/src/lang.c
+++ b/src/lang.c
@@ -110,6 +110,7 @@ bc_func_init(BcFunc* f, const char* name)
 
 		f->nparams = 0;
 		f->voidfn = false;
+		f->stackfn = BC_G;
 	}
 
 #endif // BC_ENABLED


### PR DESCRIPTION
Hello!

With your permission, I’d like to propose a small improvement to the bc syntax. I hope this won’t come across as too presumptuous.

There are several global variables in **bc** that affect a lot of things. Two of the most important are probably **ibase** and **scale**. Quite often, you have to save them at the beginning and restore them at the end of your functions, especially in library functions.

**bc** has a special flag that, if specified, changes this behavior — on entry to every function, the values of these and other global variables are pushed onto a special stack, and on exit they are restored from it.

But library functions, for universality, are still written without relying on this flag being set. For example, here’s a library function for cosine:

```bc
define c(x){
    auto b, s
    b = ibase
    ibase = A
    s = scale
    scale *= 1.2
    x = s(2*a(1)+x)
    scale = s
    ibase = b
    return(x/1)
}
```

So, I thought it would be nice to have a directive that, when specified, always enables this stack for the function it marks; in addition, it would be useful to have a function that restores the values of global variables even before exiting the function. Sometimes this is necessary to return a number according to the parameters currently set in those variables.

With these new features, the cosine function would look like this:

```bc
define stack c(x){
    ibase = A
    scale *= 1.2
    x = s(2*a(1)+x)
    global_pop()
    return(x/1)
}
```