### PR TITLE
handle early EOF correctly to avoid infinite loop in fixed-size read

### DIFF
--- a/gen/strgen.c
+++ b/gen/strgen.c
@@ -198,16 +198,15 @@ bc_read_file(const char* path)
 	buf2 = buf;
 	to_read = size;
 
-	do
+	while (to_read)
 	{
 		// Read the file. We just bail if a signal interrupts. This is so that
 		// users can interrupt the reading of big files if they want.
 		ssize_t r = read(fd, buf2, to_read);
-		if (BC_ERR(r < 0)) exit(e);
+		if (BC_ERR(r <= 0)) exit(e);
 		to_read -= (size_t) r;
 		buf2 += (size_t) r;
 	}
-	while (to_read);
 
 	// Got to have a nul byte.
 	buf[size] = '\0';

--- a/src/read.c
+++ b/src/read.c
@@ -296,16 +296,15 @@ bc_read_file(const char* path)
 	buf2 = buf;
 	to_read = size;
 
-	do
+	while (to_read)
 	{
 		// Read the file. We just bail if a signal interrupts. This is so that
 		// users can interrupt the reading of big files if they want.
 		ssize_t r = read(fd, buf2, to_read);
-		if (BC_ERR(r < 0)) goto read_err;
+		if (BC_ERR(r <= 0)) goto read_err;
 		to_read -= (size_t) r;
 		buf2 += (size_t) r;
 	}
-	while (to_read);
 
 	// Got to have a nul byte.
 	buf[size] = '\0';


### PR DESCRIPTION
## Problem
When reading a file using a size obtained from `fstat()`, the file may become shorter before all expected bytes are read.

If `read()` returns `0` while bytes are still expected, the loop does not make progress and can become non-terminating.

---

## Root Cause
- The loop only treats `read() < 0` as an error  
- `read() == 0` (early EOF) is not handled  
- Use of `do/while` causes the loop to execute even when no bytes are required  

---

## Fix
- Replace `do/while` with `while (to_read)`  
- Treat `read() <= 0` as an error when bytes are still expected  
- Apply the same change to `gen/strgen.c` to keep behaviour consistent  

---

## Result
- Prevents infinite loop on short reads  
- Preserves correct behaviour for empty and valid files  
- Ensures consistent handling across source and generator code  