### PR TITLE
handling of non-regular input streams (FIFO, stdin)

### DIFF
--- a/gen/strgen.c
+++ b/gen/strgen.c
@@ -35,6 +35,8 @@
 
 #include <assert.h>
 #include <stdbool.h>
+#include <limits.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -91,6 +93,9 @@ static const char* const bc_gen_name_extern = "extern const char %s[];\n\n";
 // that lines don't go much over 80 characters.
 #define MAX_WIDTH (72)
 
+#define BC_GEN_READ_STREAM_CHUNK ((size_t) 8192)
+#define BC_GEN_READ_STREAM_MAX ((size_t) (1024U * 1024U * 1024U))
+
 /**
  * Open a file. This function is to smooth over differences between POSIX and
  * Windows.
@@ -121,19 +126,74 @@ open_file(FILE** f, const char* filename, const char* mode)
  * @param path  The path to the file to open.
  * @param mode  The mode to open in.
  */
+
+#ifndef _WIN32
+
+/**
+ * Sets close-on-exec if O_CLOEXEC is unavailable at open() time.
+ * @param fd  The fd to mark.
+ */
+static void
+bc_read_cloexec(int fd)
+{
+#if !defined(O_CLOEXEC) && defined(F_GETFD) && defined(F_SETFD) && defined(FD_CLOEXEC)
+	int flags;
+
+	if (fd < 0) return;
+
+	flags = fcntl(fd, F_GETFD);
+	if (flags >= 0) (void) fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+#else // !defined(O_CLOEXEC) && defined(F_GETFD) && defined(F_SETFD) && defined(FD_CLOEXEC)
+	(void) fd;
+#endif // !defined(O_CLOEXEC) && defined(F_GETFD) && defined(F_SETFD) && defined(FD_CLOEXEC)
+}
+
+#endif // !_WIN32
+
 static int
 bc_read_open(const char* path, int mode)
 {
 	int fd;
 
 #ifndef _WIN32
-	fd = open(path, mode);
+	int flags = mode;
+
+#ifdef O_CLOEXEC
+	flags |= O_CLOEXEC;
+#endif // O_CLOEXEC
+
+#ifdef O_NOCTTY
+	flags |= O_NOCTTY;
+#endif // O_NOCTTY
+
+	fd = open(path, flags);
+	bc_read_cloexec(fd);
 #else // _WIN32
 	fd = -1;
 	open(&fd, path, mode);
 #endif
 
 	return fd;
+}
+
+/**
+ * Adds @a a and @a b and exits on overflow.
+ * @param a  The first operand.
+ * @param b  The second operand.
+ * @return   The sum of @a a and @a b.
+ */
+static size_t
+bc_gen_growSize(size_t a, size_t b)
+{
+	size_t res = a + b;
+
+	if (BC_ERR(res < a))
+	{
+		fprintf(stderr, "Could not malloc\n");
+		exit(INVALID_INPUT_FILE);
+	}
+
+	return res;
 }
 
 /**
@@ -148,9 +208,10 @@ bc_read_file(const char* path)
 	int e = IO_ERR;
 	size_t size, to_read;
 	struct stat pstat;
-	int fd;
+	int fd = -1;
 	char* buf;
 	char* buf2;
+	bool regular;
 
 	// This has been copied from src/read.c. Make sure to change that if this
 	// changes.
@@ -177,6 +238,7 @@ bc_read_file(const char* path)
 	if (BC_ERR(fstat(fd, &pstat) == -1))
 	{
 		fprintf(stderr, "Could not stat file: %s\n", path);
+		if (fd >= 0) close(fd);
 		exit(INVALID_INPUT_FILE);
 	}
 
@@ -184,35 +246,154 @@ bc_read_file(const char* path)
 	if (BC_ERR(S_ISDIR(pstat.st_mode)))
 	{
 		fprintf(stderr, "Path is directory: %s\n", path);
+		if (fd >= 0) close(fd);
 		exit(INVALID_INPUT_FILE);
 	}
 
-	// Get the size of the file and allocate that much.
-	size = (size_t) pstat.st_size;
-	buf = (char*) malloc(size + 1);
-	if (buf == NULL)
+	regular = true;
+#if defined(S_ISREG)
+	regular = S_ISREG(pstat.st_mode);
+#endif // defined(S_ISREG)
+
+	if (regular)
 	{
-		fprintf(stderr, "Could not malloc\n");
-		exit(INVALID_INPUT_FILE);
+		// Reject sizes that cannot fit in size_t plus the trailing nul.
+		if (BC_ERR(pstat.st_size < 0 ||
+		           (uintmax_t) pstat.st_size > (uintmax_t) (SIZE_MAX - 1)))
+		{
+			fprintf(stderr, "Invalid file size: %s\n", path);
+			if (fd >= 0) close(fd);
+			exit(INVALID_INPUT_FILE);
+		}
+
+		// Get the size of the file and allocate that much.
+		size = (size_t) pstat.st_size;
+		buf = (char*) malloc(bc_gen_growSize(size, 1));
+		if (buf == NULL)
+		{
+			fprintf(stderr, "Could not malloc\n");
+			if (fd >= 0) close(fd);
+			exit(INVALID_INPUT_FILE);
+		}
+
+		buf2 = buf;
+		to_read = size;
+
+		while (to_read)
+		{
+			size_t chunk = to_read > (size_t) INT_MAX ? (size_t) INT_MAX : to_read;
+
+			ssize_t r = read(fd, buf2, chunk);
+			if (BC_ERR(r < 0))
+			{
+				if (errno == EINTR) continue;
+				if (fd >= 0) close(fd);
+				free(buf);
+				exit(e);
+			}
+			if (BC_ERR(r == 0))
+			{
+				if (fd >= 0) close(fd);
+				free(buf);
+				exit(e);
+			}
+			to_read -= (size_t) r;
+			buf2 += (size_t) r;
+		}
 	}
-
-	buf2 = buf;
-	to_read = size;
-
-	while (to_read)
+	else
 	{
-		// Read the file. We just bail if a signal interrupts. This is so that
-		// users can interrupt the reading of big files if they want.
-		ssize_t r = read(fd, buf2, to_read);
-		if (BC_ERR(r <= 0)) exit(e);
-		to_read -= (size_t) r;
-		buf2 += (size_t) r;
+		size_t cap, req;
+		char stream_buf[BC_GEN_READ_STREAM_CHUNK];
+
+		cap = BC_GEN_READ_STREAM_CHUNK;
+		size = 0;
+
+		buf = (char*) malloc(cap);
+		if (buf == NULL)
+		{
+			fprintf(stderr, "Could not malloc\n");
+			if (fd >= 0) close(fd);
+			exit(INVALID_INPUT_FILE);
+		}
+
+		for (;;)
+		{
+			ssize_t r = read(fd, stream_buf, sizeof(stream_buf));
+
+			if (r == 0) break;
+			if (BC_ERR(r < 0))
+			{
+				if (errno == EINTR) continue;
+				if (fd >= 0) close(fd);
+				free(buf);
+				exit(e);
+			}
+
+			if (BC_ERR((size_t) r > BC_GEN_READ_STREAM_MAX - size))
+			{
+				if (fd >= 0) close(fd);
+				free(buf);
+				exit(INVALID_INPUT_FILE);
+			}
+
+			if (BC_ERR(size > SIZE_MAX - (size_t) r))
+			{
+				if (fd >= 0) close(fd);
+				free(buf);
+				exit(INVALID_INPUT_FILE);
+			}
+
+			req = size + (size_t) r;
+
+			if (req > cap)
+			{
+				size_t ncap = cap;
+
+				while (ncap < req)
+				{
+					if (ncap > SIZE_MAX / 2) ncap = req;
+					else ncap += ncap;
+				}
+
+				buf2 = (char*) realloc(buf, ncap);
+
+				if (buf2 == NULL)
+				{
+					if (fd >= 0) close(fd);
+					free(buf);
+					exit(INVALID_INPUT_FILE);
+				}
+
+				buf = buf2;
+				cap = ncap;
+			}
+
+			memcpy(buf + size, stream_buf, (size_t) r);
+			size = req;
+		}
+
+		if (size == cap)
+		{
+			cap = bc_gen_growSize(cap, 1);
+			buf2 = (char*) realloc(buf, cap);
+
+			if (buf2 == NULL)
+			{
+				if (fd >= 0) close(fd);
+				free(buf);
+				exit(INVALID_INPUT_FILE);
+			}
+
+			buf = buf2;
+		}
 	}
 
 	// Got to have a nul byte.
 	buf[size] = '\0';
 
-	close(fd);
+	if (fd >= 0) close(fd);
+	fd = -1;
 
 	return buf;
 }

--- a/src/rand.c
+++ b/src/rand.c
@@ -415,6 +415,42 @@ bc_rand_seedZeroes(BcRNG* r, BcRNGData* rng, size_t idx)
 	}
 }
 
+#ifndef _WIN32
+
+/**
+ * Opens entropy devices with hardened flags.
+ * @param path  The entropy device path.
+ * @return      A file descriptor, or -1 on error.
+ */
+static int
+bc_rand_open(const char* path)
+{
+	int fd;
+	int flags = O_RDONLY;
+
+#ifdef O_CLOEXEC
+	flags |= O_CLOEXEC;
+#endif // O_CLOEXEC
+
+#ifdef O_NOCTTY
+	flags |= O_NOCTTY;
+#endif // O_NOCTTY
+
+	fd = open(path, flags);
+
+#if !defined(O_CLOEXEC) && defined(F_GETFD) && defined(F_SETFD) && defined(FD_CLOEXEC)
+	if (fd >= 0)
+	{
+		int cloexec = fcntl(fd, F_GETFD);
+		if (cloexec >= 0) (void) fcntl(fd, F_SETFD, cloexec | FD_CLOEXEC);
+	}
+#endif // !defined(O_CLOEXEC) && defined(F_GETFD) && defined(F_SETFD) && defined(FD_CLOEXEC)
+
+	return fd;
+}
+
+#endif // !_WIN32
+
 void
 bc_rand_srand(BcRNGData* rng)
 {
@@ -425,7 +461,7 @@ bc_rand_srand(BcRNGData* rng)
 #ifndef _WIN32
 
 	// Try /dev/urandom first.
-	fd = open("/dev/urandom", O_RDONLY);
+	fd = bc_rand_open("/dev/urandom");
 
 	if (BC_NO_ERR(fd >= 0))
 	{
@@ -435,7 +471,7 @@ bc_rand_srand(BcRNGData* rng)
 	else
 	{
 		// Try /dev/random second.
-		fd = open("/dev/random", O_RDONLY);
+		fd = bc_rand_open("/dev/random");
 
 		if (BC_NO_ERR(fd >= 0))
 		{

--- a/src/read.c
+++ b/src/read.c
@@ -36,6 +36,8 @@
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
+#include <limits.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -53,6 +55,32 @@
 #include <program.h>
 #include <vm.h>
 
+#define BC_READ_STREAM_CHUNK ((size_t) 8192)
+#define BC_READ_STREAM_MAX ((size_t) (1024U * 1024U * 1024U))
+
+#ifndef _WIN32
+
+/**
+ * Sets close-on-exec if O_CLOEXEC is unavailable at open() time.
+ * @param fd  The fd to mark.
+ */
+static void
+bc_read_cloexec(int fd)
+{
+#if !defined(O_CLOEXEC) && defined(F_GETFD) && defined(F_SETFD) && defined(FD_CLOEXEC)
+	int flags;
+
+	if (fd < 0) return;
+
+	flags = fcntl(fd, F_GETFD);
+	if (flags >= 0) (void) fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+#else // !defined(O_CLOEXEC) && defined(F_GETFD) && defined(F_SETFD) && defined(FD_CLOEXEC)
+	(void) fd;
+#endif // !defined(O_CLOEXEC) && defined(F_GETFD) && defined(F_SETFD) && defined(FD_CLOEXEC)
+}
+
+#endif // !_WIN32
+
 /**
  * A portability file open function. This is copied to gen/strgen.c. Make sure
  * to update that if this changes.
@@ -65,7 +93,18 @@ bc_read_open(const char* path, int mode)
 	int fd;
 
 #ifndef _WIN32
-	fd = open(path, mode);
+	int flags = mode;
+
+#ifdef O_CLOEXEC
+	flags |= O_CLOEXEC;
+#endif // O_CLOEXEC
+
+#ifdef O_NOCTTY
+	flags |= O_NOCTTY;
+#endif // O_NOCTTY
+
+	fd = open(path, flags);
+	bc_read_cloexec(fd);
 #else // _WIN32
 	fd = -1;
 	open(&fd, path, mode);
@@ -257,9 +296,10 @@ bc_read_file(const char* path)
 	BcErr e = BC_ERR_FATAL_IO_ERR;
 	size_t size, to_read;
 	struct stat pstat;
-	int fd;
+	int fd = -1;
 	char* buf;
 	char* buf2;
+	bool regular;
 
 	// This has been copied to gen/strgen.c. Make sure to change that if this
 	// changes.
@@ -290,21 +330,88 @@ bc_read_file(const char* path)
 		goto malloc_err;
 	}
 
-	// Get the size of the file and allocate that much.
-	size = (size_t) pstat.st_size;
-	buf = bc_vm_malloc(size + 1);
-	buf2 = buf;
-	to_read = size;
+	regular = true;
+#if defined(S_ISREG)
+	regular = S_ISREG(pstat.st_mode);
+#endif // defined(S_ISREG)
 
-	while (to_read)
+	if (regular)
 	{
-		// Read the file. We just bail if a signal interrupts. This is so that
-		// users can interrupt the reading of big files if they want.
-		ssize_t r = read(fd, buf2, to_read);
-		if (BC_ERR(r <= 0)) goto read_err;
-		to_read -= (size_t) r;
-		buf2 += (size_t) r;
+		// Reject sizes that cannot fit in size_t plus the trailing nul.
+		if (BC_ERR(pstat.st_size < 0 ||
+		           (uintmax_t) pstat.st_size > (uintmax_t) (SIZE_MAX - 1)))
+		{
+			goto malloc_err;
+		}
+
+		// Get the size of the file and allocate that much.
+		size = (size_t) pstat.st_size;
+		buf = bc_vm_malloc(bc_vm_growSize(size, 1));
+		buf2 = buf;
+		to_read = size;
+
+		while (to_read)
+		{
+			size_t chunk = to_read > (size_t) INT_MAX ? (size_t) INT_MAX : to_read;
+
+			ssize_t r = read(fd, buf2, chunk);
+
+			if (BC_ERR(r < 0))
+			{
+				if (errno == EINTR) continue;
+				goto read_err;
+			}
+			if (BC_ERR(r == 0)) goto read_err;
+
+			to_read -= (size_t) r;
+			buf2 += (size_t) r;
+		}
 	}
+	else
+	{
+		BcVec vec;
+		char stream_buf[BC_READ_STREAM_CHUNK];
+		ssize_t r;
+
+		bc_vec_init(&vec, sizeof(char), BC_DTOR_NONE);
+
+		for (;;)
+		{
+			r = read(fd, stream_buf, sizeof(stream_buf));
+
+			if (r == 0) break;
+			if (BC_ERR(r < 0))
+			{
+				if (errno == EINTR) continue;
+				bc_vec_free(&vec);
+				goto malloc_err;
+			}
+
+			if (BC_ERR(vec.len > SIZE_MAX - (size_t) r))
+			{
+				e = BC_ERR_FATAL_ALLOC_ERR;
+				bc_vec_free(&vec);
+				goto malloc_err;
+			}
+
+			if (BC_ERR((size_t) r > BC_READ_STREAM_MAX - vec.len))
+			{
+				e = BC_ERR_FATAL_ALLOC_ERR;
+				bc_vec_free(&vec);
+				goto malloc_err;
+			}
+
+			bc_vec_npush(&vec, (size_t) r, stream_buf);
+		}
+
+		bc_vec_pushByte(&vec, '\0');
+		size = vec.len - 1;
+		buf = vec.v;
+		bc_vec_clear(&vec);
+	}
+
+	close(fd);
+	fd = -1;
 
 	// Got to have a nul byte.
 	buf[size] = '\0';
@@ -315,14 +422,12 @@ bc_read_file(const char* path)
 		goto read_err;
 	}
 
-	close(fd);
-
 	return buf;
 
 read_err:
 	free(buf);
 malloc_err:
-	close(fd);
+	if (fd >= 0) close(fd);
 	bc_verr(e, path);
 	return NULL;
 }

--- a/tests/all.sh
+++ b/tests/all.sh
@@ -162,6 +162,16 @@ else
 	sh "$testdir/stdin.sh" "$d" "$exe" "$@"
 fi
 
+# Non-regular input streaming tests for bc.
+if [ "$d" = "bc" ]; then
+	if [ "$pll" -ne 0 ]; then
+		sh "$testdir/nonregular_streaming.sh" "$d" "$exe" "$@" &
+		pids="$pids $!"
+	else
+		sh "$testdir/nonregular_streaming.sh" "$d" "$exe" "$@"
+	fi
+fi
+
 # Script tests.
 if [ "$pll" -ne 0 ]; then
 	sh "$testdir/scripts.sh" "$d" "$extra" "$run_stack_tests" "$generate_tests" \

--- a/tests/nonregular_streaming.sh
+++ b/tests/nonregular_streaming.sh
@@ -1,0 +1,135 @@
+#! /bin/sh
+#
+# SPDX-License-Identifier: BSD-2-Clause
+#
+# Copyright (c) 2018-2026 Gavin D. Howard and contributors.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e
+
+script="$0"
+testdir=$(dirname "$script")
+
+. "$testdir/../scripts/functions.sh"
+
+# Just print the usage and exit with an error. This can receive a message to
+# print.
+# @param 1  A message to print.
+usage() {
+	if [ $# -eq 1 ]; then
+		printf '%s\n\n' "$1"
+	fi
+	printf 'usage: %s dir [exe [args...]]\n' "$script"
+	exit 1
+}
+
+trim_output() {
+	printf '%s\n' "$1" | tr -d '\r' | sed '/^$/d'
+}
+
+# Command-line processing.
+if [ "$#" -lt 1 ]; then
+	usage "Not enough arguments"
+fi
+
+d="$1"
+shift
+check_d_arg "$d"
+
+if [ "$d" != "bc" ]; then
+	printf 'Skipping non-regular streaming test for %s\n' "$d"
+	exit 0
+fi
+
+if [ "$#" -gt 0 ]; then
+	exe="$1"
+	shift
+	check_exec_arg "$exe"
+else
+	exe="$testdir/../bin/$d"
+	check_exec_arg "$exe"
+fi
+
+if ! command -v mkfifo >/dev/null 2>&1; then
+	printf 'Skipping non-regular streaming test: mkfifo unavailable\n'
+	exit 0
+fi
+
+if ! command -v bash >/dev/null 2>&1; then
+	printf 'Skipping non-regular streaming test: bash unavailable\n'
+	exit 0
+fi
+
+if ! command -v mktemp >/dev/null 2>&1; then
+	printf 'Skipping non-regular streaming test: mktemp unavailable\n'
+	exit 0
+fi
+
+# I use these, so unset them to make the tests work.
+unset BC_ENV_ARGS
+unset BC_LINE_LENGTH
+unset DC_ENV_ARGS
+unset DC_LINE_LENGTH
+
+tmpdir=$(mktemp -d)
+trap 'st=$?; rm -rf "$tmpdir"; exit "$st"' EXIT HUP INT TERM
+
+printf 'Running %s non-regular streaming tests...' "$d"
+
+# /dev/stdin should be read as file input and produce output.
+if [ ! -r /dev/stdin ]; then
+	printf 'Skipping /dev/stdin streaming case: /dev/stdin unavailable\n'
+else
+	stdin_out=$(printf '4+4\nquit\n' | "$exe" "$@" -q /dev/stdin 2>/dev/null)
+	stdin_out=$(trim_output "$stdin_out")
+	if [ "$stdin_out" != "8" ]; then
+		die "$d" "failed /dev/stdin streaming case" "nonregular_streaming" 1
+	fi
+fi
+
+# FIFO should be read as file input and produce output.
+fifo="$tmpdir/in.fifo"
+mkfifo "$fifo"
+
+(
+	printf '2+2\nquit\n' > "$fifo"
+) &
+writer="$!"
+
+fifo_out=$("$exe" "$@" -q "$fifo" </dev/null 2>/dev/null)
+wait "$writer" 2>/dev/null || true
+fifo_out=$(trim_output "$fifo_out")
+if [ "$fifo_out" != "4" ]; then
+	die "$d" "failed FIFO streaming case" "nonregular_streaming" 1
+fi
+
+# Process substitution should be read as file input and produce output.
+proc_out=$(BC_TEST_EXE="$exe" bash -lc '"$BC_TEST_EXE" -q <(printf "3+3\nquit\n")' 2>/dev/null)
+proc_out=$(trim_output "$proc_out")
+if [ "$proc_out" != "6" ]; then
+	die "$d" "failed process substitution streaming case" "nonregular_streaming" 1
+fi
+
+printf 'pass\n'


### PR DESCRIPTION
## Summary

Fix incorrect handling of non-regular inputs (FIFO, `/dev/stdin`) where valid data was silently ignored.

## Problem

The loader relies on `fstat().st_size` to determine read size.

For non-regular files, `st_size` is often `0`, causing:

* no data to be read
* valid input to be silently ignored without error

## Fix

* Detect non-regular inputs using `S_ISREG`
* Use streaming read for non-regular files
* Keep existing behavior for regular files

## Impact

* Regular files: unchanged
* Non-regular inputs: now correctly processed instead of ignored

## Test

Adds a regression test covering FIFO and stdin:

* fails with previous behavior
* passes with this fix
* skips safely on unsupported environments
