### PR TITLE
zero vals before assembling seed in bcl_rand_seed

### DIFF
--- a/src/library.c
+++ b/src/library.c
@@ -1701,6 +1701,9 @@ bcl_rand_seed(unsigned char seed[BCL_SEED_SIZE])
 
 	BC_FUNC_HEADER(vm, err);
 
+	// The loop below OR's into vals, so it must start zeroed.
+	memset(vals, 0, sizeof(vals));
+
 	// Fill the array.
 	for (i = 0; i < BCL_SEED_SIZE; ++i)
 	{


### PR DESCRIPTION
bcl_rand_seed() OR's the seed bytes into the local `vals` array without zeroing it first, so the PRNG is seeded with leftover stack data instead of the bytes passed in. bcl(3) documents it as seeding with exactly those bytes, and bcl_rand_seed2num() then reads that contaminated state back. Zero vals before the loop.